### PR TITLE
Update README and inline documentation 

### DIFF
--- a/EosioSwiftVault/EosioVault.swift
+++ b/EosioSwiftVault/EosioVault.swift
@@ -80,6 +80,8 @@ public final class EosioVault {
     ///   - metadata: Any metadata to associate with this key.
     /// - Returns: The new key as a VaultKey.
     /// - Throws: If a new key cannot be created.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func newSecureEnclaveKey(bioFactor: BioFactor = .none, metadata: [String: Any]? = nil) throws -> EosioVault.VaultKey {
         return try newVaultKey(secureEnclave: true, bioFactor: bioFactor, metadata: metadata)
     }
@@ -92,6 +94,8 @@ public final class EosioVault {
     ///   - metadata: Any metadata to associate with this key.
     /// - Returns: The new key as a VaultKey.
     /// - Throws: If a new key cannot be created.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func newVaultKey(secureEnclave: Bool, bioFactor: BioFactor = .none, metadata: [String: Any]? = nil) throws -> EosioVault.VaultKey {
         var tag: String?
         var accessFlag: SecAccessControlCreateFlags?
@@ -127,6 +131,8 @@ public final class EosioVault {
     ///   - metadata: Any metadata to associate with this key.
     /// - Returns: The imported key as a VaultKey.
     /// - Throws: If the key is not valid or cannot be imported.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func addExternal(eosioPrivateKey: String, metadata: [String: Any]? = nil) throws -> EosioVault.VaultKey {
         let eosioKeyComponents = try eosioPrivateKey.eosioComponents()
         let curve = try EllipticCurveType(eosioKeyComponents.version)
@@ -167,6 +173,8 @@ public final class EosioVault {
     ///
     /// - Parameter key: The VaultKey to update.
     /// - Returns: True if the key was updated, otherwise false.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func update(key: EosioVault.VaultKey) -> Bool {
         return saveKeyMetadata(eosioPublicKey: key.eosioPublicKey, dictionary: key.metadata)
     }
@@ -324,12 +332,16 @@ public final class EosioVault {
     ///   - eosioPublicKey: The EOSIO public key.
     ///   - dictionary: A metadata dictionary to save.
     /// - Returns: True if the metadata was saved, otherwise false.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func saveKeyMetadata(eosioPublicKey: String, dictionary: [String: Any]) -> Bool {
         guard let json = dictionary.jsonString else { return false }
         return saveKeyMetadata(eosioPublicKey: eosioPublicKey, json: json)
     }
 
     /// Save metadata for the eosioPublicKey
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     private func saveKeyMetadata(eosioPublicKey: String, json: String) -> Bool {
         let name = eosioPublicKey
         var result = false
@@ -347,6 +359,8 @@ public final class EosioVault {
     /// Delete metadata for the eosioPublicKey.
     ///
     /// - Parameter publicKey: The public key.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func deleteKeyMetadata(publicKey: String) {
         keychain.delete(name: publicKey, service: eosioKeyMetadataService)
     }
@@ -355,6 +369,8 @@ public final class EosioVault {
     ///
     /// - Parameter eosioPublicKey: An EOSIO public key.
     /// - Returns: The metadata dictionary for the key, if existing.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func getKeyMetadata(eosioPublicKey: String) -> [String: Any]? {
         guard let json = keychain.getValue(name: eosioPublicKey, service: eosioKeyMetadataService) else { return nil }
         return json.toJsonDictionary
@@ -363,6 +379,8 @@ public final class EosioVault {
     /// Get metadata for all keys.
     ///
     /// - Returns: Dictionary of metadata dictionaries for all keys.
+    /// - Important: Metadata must follow the rules for JSONSerialization.
+    /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
     public func getAllKeysMetadata() -> [String: [String: Any]]? {
         guard let values = keychain.getValues(service: eosioKeyMetadataService) else { return nil }
         var keyMetadataArray = [String: [String: Any]]()

--- a/EosioSwiftVault/EosioVaultKey.swift
+++ b/EosioSwiftVault/EosioVaultKey.swift
@@ -52,6 +52,8 @@ public extension EosioVault {
         /// Is the key retired? Retired keys have metadata without a key in the Keychain.
         private (set) public var isRetired: Bool
         /// Metadata for this key.
+        /// - Important: Metadata must follow the rules for JSONSerialization.
+        /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
         public var metadata: [String: Any]
 
         /// Init a VaultKey.
@@ -60,6 +62,8 @@ public extension EosioVault {
         ///   - eosioPublicKey: An EOSIO public key.
         ///   - ecKey: An ECKey.
         ///   - metadata: Metadata dictionary.
+        /// - Important: Metadata must follow the rules for JSONSerialization.
+        /// - SeeAlso: https://developer.apple.com/documentation/foundation/jsonserialization
         init?(eosioPublicKey: String? = nil, ecKey: Keychain.ECKey?, metadata: [String: Any]?) {
 
             // Case of publicKey + metadata with no ecKey = retired key

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The `accessGroup` is a [App Group Identifier](https://developer.apple.com/docume
 
 ## Key Generation
 
-The Vault library exposes functions to generate new EOSIO keys. New keys can either be generated and stored in the device's [Secure Enclave](https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/storing_keys_in_the_secure_enclave) or the Keychain. **Note:** If the key is stored in Secure Enclave, it is not possible to directly access or export the private key. 
+The Vault library exposes functions to generate new EOSIO keys. New keys can either be generated and stored in the device's [Secure Enclave](https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/storing_keys_in_the_secure_enclave) or the Keychain. **Note:** If the key is stored in Secure Enclave, it is not possible to directly access or export the private key.
+
+**Important:** Currently key metadata must conform to the rules for conversion by [JSONSerialization](https://developer.apple.com/documentation/foundation/jsonserialization).  Failure to do so will result in application errors. 
 
 To create a key in Secure Enclave:
 


### PR DESCRIPTION
Document that the key metadata must conform to the conversion rules for JSONSerialization.