### PR TITLE
Todd/learnings

### DIFF
--- a/EosioSwiftVault/EosioVault.swift
+++ b/EosioSwiftVault/EosioVault.swift
@@ -63,6 +63,16 @@ public final class EosioVault {
         return key.uncompressedPublicKey.hex
     }
 
+    /// Compute the uncompressed public key for an eosio key
+    /// - Parameter eosioPublicKey: The eosio public key
+    /// - Throws: If the uncompressed public key cannot be computed
+    /// - Returns: The uncompressed public key
+    public func getUncompressedPublicKey(eosioPublicKey: String) throws -> Data {
+        let components = try eosioPublicKey.eosioComponents()
+        let cPubKeyData = try Data(eosioPublicKey: eosioPublicKey)
+        return try keychain.uncompressedPublicKey(data: cPubKeyData, curve: components.version)
+    }
+
     /// Create a new Secure Enclave key and return the Vault Key.
     ///
     /// - Parameters:

--- a/EosioSwiftVault/EosioVault.swift
+++ b/EosioSwiftVault/EosioVault.swift
@@ -152,10 +152,7 @@ public final class EosioVault {
             throw EosioError(.keyManagementError, reason: "Unable to create compressed public key")
         }
         let eosioPublicKey = try compressedPublicKey.toEosioPublicKey(curve: curve.rawValue)
-        guard let label = publicKeyData.compressedPublicKey?.hex else {
-            throw EosioError(.keyManagementError, reason: "Unable to create public key")
-        }
-        let ecKey = try keychain.importExternal(privateKey: publicKeyData + privateKeyData, tag: tag, label: label, protection: protection, accessFlag: accessFlag)
+        let ecKey = try keychain.importExternal(privateKey: publicKeyData + privateKeyData, tag: tag, label: nil, protection: protection, accessFlag: accessFlag)
 
         // Don't read from the keychain as this might trigger a biometric check, instead create the vaultKey from the eosioPublicKey, ecKey & metadata
         guard var vaultKey = VaultKey(eosioPublicKey: eosioPublicKey, ecKey: ecKey, metadata: metadata) else {

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -351,7 +351,6 @@ public class Keychain {
         return array
     }
 
-
     /// Get an elliptic curve keys for the provided application label (for ec keys this is the sha1 hash of the public key)
     /// - Parameter applicationLabel: The application label to search for
     /// - Throws: If there is a error getting the key

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -578,7 +578,7 @@ public class Keychain {
         // Previously at this point the key was read back from the keychain and returned. (See comment above)
         // However, if the key had a biometric restriction, the system would prompt with a biometric challenge.
         // So, instead construct the key attributes dictionary from in scope data to create the ECKey to return
-        var keyatt: [String:Any] = [
+        var keyatt: [String: Any] = [
             kSecAttrAccessGroup as String: accessGroup,
             kSecValueRef as String: secKey
         ]
@@ -689,12 +689,12 @@ public class Keychain {
     /// - Returns: An ECKey.
     /// - Throws: If a key cannot be created.
     public func createEllipticCurveKey(secureEnclave: Bool, tag: String? = nil, label: String? = nil,
-                                          protection: AccessibleProtection = .whenUnlockedThisDeviceOnly,
-                                          accessFlag: SecAccessControlCreateFlags? = nil) throws -> ECKey {
+                                       protection: AccessibleProtection = .whenUnlockedThisDeviceOnly,
+                                       accessFlag: SecAccessControlCreateFlags? = nil) throws -> ECKey {
 
         let secKey = try createEllipticCurveSecKey(secureEnclave: secureEnclave, tag: tag, label: label, protection: protection, accessFlag: accessFlag)
 
-        var keyatt: [String:Any] = [
+        var keyatt: [String: Any] = [
             kSecAttrAccessGroup as String: accessGroup,
             kSecValueRef as String: secKey
         ]

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -297,6 +297,7 @@ public class Keychain {
     }
 
     /// Get all attributes for elliptic curve keys with option to filter by tag.
+    /// IMPORTANT: If any of the keys returned by the  search query require a biometric check for access, the system will prompt the user for FaceID/TouchID
     ///
     /// - Parameter tag: The tag to filter by (defaults to `nil`).
     /// - Returns: An array of ECKeys.
@@ -334,6 +335,8 @@ public class Keychain {
     }
 
     /// Get an elliptic curve keys for the provided application label (for ec keys this is the sha1 hash of the public key)
+    /// IMPORTANT: If the key  requires a biometric check for access, the system will prompt the user for FaceID/TouchID
+    ///
     /// - Parameter applicationLabel: The application label to search for
     /// - Throws: If there is a error getting the key
     /// - Returns: An ECKey
@@ -362,6 +365,8 @@ public class Keychain {
     }
 
     /// Get an elliptic curve keys for the provided public key
+    /// IMPORTANT: If the key  requires a biometric check for access, the system will prompt the user for FaceID/TouchID
+    ///
     /// - Parameter publicKey: The publickey
     /// - Throws: If there is a error getting the key
     /// - Returns: An ECKey
@@ -386,6 +391,7 @@ public class Keychain {
     }
 
     /// Get all elliptic curve keys and return the public keys.
+    /// IMPORTANT: If any of the keys returned by the  search query require a biometric check for access, the system will prompt the user for FaceID/TouchID
     ///
     /// - Returns: An array of public SecKeys.
     public func getAllEllipticCurvePublicSecKeys() -> [SecKey]? {

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Security
 import EosioSwift
+import BigInt
 
 /// General class for interacting with the Keychain and Secure Enclave.
 public class Keychain {

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -290,7 +290,7 @@ public class Keychain {
                 keys.append(key)
             } else {
                 // if error try to lookup this key again using the applicationLabel (sha1 of the public key)
-                // sometimes if there are a large number of keys returned, the key ref seems to me missing, but getting the key again with the application label works
+                // sometimes if there are a large number of keys returned, the key ref seems to be missing, but getting the key again with the application label works
                 if let applicationLabel = attributes[kSecAttrApplicationLabel as String] as? Data, let key = try? getEllipticCurveKey(applicationLabel: applicationLabel) {
                     keys.append(key)
                 }
@@ -316,9 +316,9 @@ public class Keychain {
             kSecReturnRef as String: true
         ]
         if matchLimitAll {
-            query[kSecMatchLimit as String as String] = kSecMatchLimitAll
+            query[kSecMatchLimit as String] = kSecMatchLimitAll
         } else {
-            query[kSecMatchLimit as String as String] = kSecMatchLimitOne
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
         }
         if let tag = tag {
             query[kSecAttrApplicationTag as String] = tag

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -380,6 +380,16 @@ public class Keychain {
         return try ECKey.new(attributes: attributes)
     }
 
+    /// Get an elliptic curve keys for the provided public key
+    /// - Parameter publicKey: The publickey
+    /// - Throws: If there is a error getting the key
+    /// - Returns: An ECKey
+    public func getR1EllipticCurveKey(publicKey: Data) throws -> ECKey {
+        let uncompressedPublicKey = try uncompressedR1PublicKey(data: publicKey)
+        print(uncompressedPublicKey.hex)
+        return try getEllipticCurveKey(applicationLabel: uncompressedPublicKey.sha1)
+    }
+
     /// Get all elliptic curve private Sec Keys.
     /// For Secure Enclave private keys, the SecKey is a reference. It's not posible to export the actual private key data.
     ///

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -678,6 +678,36 @@ public class Keychain {
         return privateKey
     }
 
+    /// Create a new elliptic curve key.
+    ///
+    /// - Parameters:
+    ///   - secureEnclave: Generate this key in Secure Enclave?
+    ///   - tag: A tag to associate with this key.
+    ///   - label: A label to associate with this key.
+    ///   - protection: Accessibility defaults to whenUnlockedThisDeviceOnly.
+    ///   - accessFlag: The accessFlag for this key.
+    /// - Returns: An ECKey.
+    /// - Throws: If a key cannot be created.
+    public func createEllipticCurveKey(secureEnclave: Bool, tag: String? = nil, label: String? = nil,
+                                          protection: AccessibleProtection = .whenUnlockedThisDeviceOnly,
+                                          accessFlag: SecAccessControlCreateFlags? = nil) throws -> ECKey {
+
+        let secKey = try createEllipticCurveSecKey(secureEnclave: secureEnclave, tag: tag, label: label, protection: protection, accessFlag: accessFlag)
+
+        var keyatt: [String:Any] = [
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecValueRef as String: secKey
+        ]
+        if let tag = tag {
+            keyatt[kSecAttrApplicationTag as String] = tag
+        }
+        if let label = label {
+            keyatt[kSecAttrLabel as String] = label
+        }
+        let key = try ECKey.new(attributes: keyatt)
+        return key
+    }
+
     /// Sign if the key is in the Keychain.
     ///
     /// - Parameters:

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -409,19 +409,19 @@ public class Keychain {
     /// - Returns: The uncompressed R1 public key
     func uncompressedR1PublicKey(data: Data) throws -> Data {
         guard let firstByte = data.first else {
-            throw SCError(reason: "No key data provided.")
+            throw EosioError(.keyManagementError, reason: "No key data provided.")
         }
         guard firstByte == 2 || firstByte == 3 || firstByte == 4 else {
-            throw SCError(reason: "\(data.hex) is not a valid public key.")
+            throw EosioError(.keyManagementError, reason: "\(data.hex) is not a valid public key.")
         }
         if firstByte == 4 {
             guard data.count == 65 else {
-                throw SCError(reason: "\(data.hex) is not a valid public key. Expecting 65 bytes.")
+                throw EosioError(.keyManagementError, reason: "\(data.hex) is not a valid public key. Expecting 65 bytes.")
             }
             return data
         }
         guard data.count == 33 else {
-            throw SCError(reason: "\(data.hex) is not a valid public key. Expecting 33 bytes.")
+            throw EosioError(.keyManagementError, reason: "\(data.hex) is not a valid public key. Expecting 33 bytes.")
         }
 
         let xData = data[1..<data.count]

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -430,7 +430,11 @@ public class Keychain {
         let b = BigInt(BigUInt(Data(hexString: "5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B")!)) // swiftlint:disable:this identifier_name
         let y = ellipticCurveY(x: x, a: a, b: b, p: p, isOdd: firstByte == 3) // swiftlint:disable:this identifier_name
         let four: UInt8 = 4
-        return [four] + xData + y.serialize()
+        var yData = y.serialize()
+        while yData.count < 32 {
+            yData = [0x00] + yData
+        }
+        return [four] + xData + yData
     }
 
     /// Import an external elliptic curve private key into the Keychain.

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -199,7 +199,7 @@ public class Keychain {
     }
 
     /// Make query to retrieve all elliptic curve keys in the Keychain.
-    private func makeQueryForAllEllipticCurveKeys(tag: String? = nil) -> [String: Any] {
+    private func makeQueryForAllEllipticCurveKeys(tag: String? = nil, label: String? = nil, secureEnclave: Bool = false ) -> [String: Any] {
         var query: [String: Any] =  [
             kSecClass as String: kSecClassKey,
             kSecMatchLimit as String: kSecMatchLimitAll,
@@ -210,6 +210,13 @@ public class Keychain {
         if let tag = tag {
             query[kSecAttrApplicationTag as String] = tag
         }
+        if let label = label {
+            query[kSecAttrLabel as String] = label
+        }
+        if secureEnclave {
+            query[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
+        }
+
         return query
     }
 

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -382,6 +382,28 @@ public class Keychain {
         return privateKey
     }
 
+
+    /// Calculate the Y component of an elliptic curve from the X and the curve params
+    /// - Parameters:
+    ///   - x: x
+    ///   - a: curve param a
+    ///   - b: curve param b
+    ///   - p: curve param p
+    ///   - isOdd: isOdd
+    /// - Returns: The Y component as a bigUInt
+    func ellipticCurveY(x: BigInt, a: BigInt, b: BigInt, p: BigInt, isOdd: Bool) -> BigUInt {
+        let y2 = (x.power(3, modulus: p) + (a * x) + b).modulus(p)
+        var y = y2.power((p+1)/4, modulus: p)
+        let yMod2 = y.modulus(2)
+        if isOdd && yMod2 != 1 || !isOdd && yMod2 != 0  {
+            y = p - y
+        }
+        return BigUInt(y)
+    }
+
+
+
+    
     /// Import an external elliptic curve private key into the Keychain.
     ///
     /// - Parameters:

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -370,10 +370,9 @@ public class Keychain {
     /// - Parameter publicKey: The publickey
     /// - Throws: If there is a error getting the key
     /// - Returns: An ECKey
-    public func getR1EllipticCurveKey(publicKey: Data) throws -> ECKey {
-        let uncompressedPublicKey = try uncompressedR1PublicKey(data: publicKey)
-        print(uncompressedPublicKey.hex)
-        return try getEllipticCurveKey(applicationLabel: uncompressedPublicKey.sha1)
+    public func getEllipticCurveKey(publicKey: Data) throws -> ECKey {
+        let uncPublicKey = try uncompressedPublicKey(data: publicKey)
+        return try getEllipticCurveKey(applicationLabel: uncPublicKey.sha1)
     }
 
     /// Get all elliptic curve private Sec Keys.
@@ -506,14 +505,6 @@ public class Keychain {
             yData = [0x00] + yData
         }
         return [four] + xData + yData
-    }
-
-    /// Compute the uncompressed R1 public key from the compressed key
-    /// - Parameter data: A public key
-    /// - Throws: If the data is not a valid public key
-    /// - Returns: The uncompressed R1 public key
-    func uncompressedR1PublicKey(data: Data) throws -> Data {
-        return try uncompressedPublicKey(data: data, curve: "R1")
     }
 
     /// Import an external elliptic curve private key into the Keychain.

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -383,7 +383,6 @@ public class Keychain {
         return privateKey
     }
 
-
     /// Calculate the Y component of an elliptic curve from the X and the curve params
     /// - Parameters:
     ///   - x: x
@@ -392,16 +391,15 @@ public class Keychain {
     ///   - p: curve param p
     ///   - isOdd: isOdd
     /// - Returns: The Y component as a bigUInt
-    func ellipticCurveY(x: BigInt, a: BigInt, b: BigInt, p: BigInt, isOdd: Bool) -> BigUInt {
-        let y2 = (x.power(3, modulus: p) + (a * x) + b).modulus(p)
-        var y = y2.power((p+1)/4, modulus: p)
+    func ellipticCurveY(x: BigInt, a: BigInt, b: BigInt, p: BigInt, isOdd: Bool) -> BigUInt { // swiftlint:disable:this identifier_name
+        let y2 = (x.power(3, modulus: p) + (a * x) + b).modulus(p) // swiftlint:disable:this identifier_name
+        var y = y2.power((p+1)/4, modulus: p) // swiftlint:disable:this identifier_name
         let yMod2 = y.modulus(2)
-        if isOdd && yMod2 != 1 || !isOdd && yMod2 != 0  {
+        if isOdd && yMod2 != 1 || !isOdd && yMod2 != 0 {
             y = p - y
         }
         return BigUInt(y)
     }
-
 
     /// Compute the uncompressed R1 public key from the compressed key
     /// - Parameter data: A public key
@@ -427,15 +425,14 @@ public class Keychain {
         let xData = data[1..<data.count]
         let x = BigInt(BigUInt(xData))
         // assume secp256r1 (curve used in Secure Enclave)
-        let p = BigInt(BigUInt(Data(hexString: "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF")!))
-        let a = BigInt(-3)
-        let b = BigInt(BigUInt(Data(hexString: "5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B")!))
-        let y = ellipticCurveY(x: x, a: a, b: b, p: p, isOdd: firstByte == 3)
+        let p = BigInt(BigUInt(Data(hexString: "FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF")!)) // swiftlint:disable:this identifier_name
+        let a = BigInt(-3) // swiftlint:disable:this identifier_name
+        let b = BigInt(BigUInt(Data(hexString: "5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B")!)) // swiftlint:disable:this identifier_name
+        let y = ellipticCurveY(x: x, a: a, b: b, p: p, isOdd: firstByte == 3) // swiftlint:disable:this identifier_name
         let four: UInt8 = 4
         return [four] + xData + y.serialize()
     }
 
-    
     /// Import an external elliptic curve private key into the Keychain.
     ///
     /// - Parameters:

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -401,19 +401,12 @@ public class Keychain {
 
     /// Get the private SecKey for the public key if the key exists in the Keychain.
     /// Public key data can be in either compressed or uncompressed format.
+    /// IMPORTANT: If the key  requires a biometric check for access, the system will prompt the user for FaceID/TouchID
     ///
     /// - Parameter publicKey: A public key in either compressed or uncompressed format.
     /// - Returns: A SecKey.
     public func getPrivateSecKey(publicKey: Data) -> SecKey? {
-        guard let allPrivateKeys = getAllEllipticCurvePrivateSecKeys() else { return nil }
-        for privateKey in allPrivateKeys {
-            if let uncompressedPubKey = privateKey.publicKey?.externalRepresentation {
-                if uncompressedPubKey == publicKey || uncompressedPubKey.compressedPublicKey == publicKey {
-                    return privateKey
-                }
-            }
-        }
-        return nil
+        return getEllipticCurveKey(publicKey: publicKey)?.privateSecKey
     }
 
     /// Create a **NON**-Secure-Enclave elliptic curve private key.

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -10,6 +10,7 @@ import Foundation
 import Security
 import EosioSwift
 import BigInt
+import CommonCrypto
 
 /// General class for interacting with the Keychain and Secure Enclave.
 public class Keychain {
@@ -726,6 +727,30 @@ public class Keychain {
         }
         return decryptedData as Data
     }
+
+}
+
+private extension Data {
+
+    var toUnsafeMutablePointerBytes: UnsafeMutablePointer<UInt8> {
+        let pointerBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: self.count)
+        self.copyBytes(to: pointerBytes, count: self.count)
+        return pointerBytes
+    }
+
+    var toUnsafePointerBytes: UnsafePointer<UInt8> {
+        return UnsafePointer(self.toUnsafeMutablePointerBytes)
+    }
+
+    /// Returns the SHA1hash of the data.
+    var sha1: Data {
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        let p = self.toUnsafePointerBytes // swiftlint:disable:this identifier_name
+        _ = CC_SHA1(p, CC_LONG(self.count), &hash)
+        p.deallocate()
+        return Data(hash)
+    }
+
 }
 
 public extension Data {

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -523,7 +523,8 @@ public class Keychain {
     ///   - accessFlag: The accessFlag for this key.
     /// - Returns: The imported key as an ECKey.
     /// - Throws: If the key is not valid or cannot be imported.
-    public func importExternal(privateKey: Data, tag: String? = nil, label: String?  = nil,
+    // swiftlint:disable:next cyclomatic_complexity
+    public func importExternal(privateKey: Data, tag: String? = nil, label: String?  = nil, // swiftlint:disable:this function_body_length
                                protection: AccessibleProtection = .whenUnlockedThisDeviceOnly,
                                accessFlag: SecAccessControlCreateFlags? = nil) throws -> ECKey {
 

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -263,11 +263,17 @@ public class Keychain {
     }
 
     /// Get an elliptic curve key given the public key.
+    /// IMPORTANT: If the key  requires a biometric check for access, the system will prompt the user for FaceID/TouchID
     ///
     /// - Parameter publicKey: The public key.
     /// - Returns: An ECKey corresponding to the public key.
     public func getEllipticCurveKey(publicKey: Data) -> ECKey? {
-        return try? getR1EllipticCurveKey(publicKey: publicKey)
+        do {
+            let eckey: ECKey = try getEllipticCurveKey(publicKey: publicKey)
+            return eckey
+        } catch {
+            return nil
+        }
     }
 
     /// Get all elliptic curve keys with option to filter by tag.

--- a/EosioSwiftVault/Keychain.swift
+++ b/EosioSwiftVault/Keychain.swift
@@ -267,15 +267,7 @@ public class Keychain {
     /// - Parameter publicKey: The public key.
     /// - Returns: An ECKey corresponding to the public key.
     public func getEllipticCurveKey(publicKey: Data) -> ECKey? {
-        guard let allKeys = try? getAllEllipticCurveKeys() else {
-            return nil
-        }
-        for key in allKeys {
-            if key.compressedPublicKey == publicKey || key.uncompressedPublicKey == publicKey {
-                return key
-            }
-        }
-        return nil
+        return try? getR1EllipticCurveKey(publicKey: publicKey)
     }
 
     /// Get all elliptic curve keys with option to filter by tag.

--- a/EosioSwiftVault/KeychainECKey.swift
+++ b/EosioSwiftVault/KeychainECKey.swift
@@ -29,7 +29,6 @@ public extension Keychain {
         private (set) public var uncompressedPublicKey: Data
         /// The compressed public key in ANSI X9.63 format (33 bytes, starts with 02 or 03).
         private (set) public var compressedPublicKey: Data
-        
 
         static func new(attributes: [String: Any]) throws -> ECKey {
             if let key = ECKey(attributes: attributes) {
@@ -47,7 +46,7 @@ public extension Keychain {
                 throw EosioError(.keyManagementError, reason: "Cannot get public key external representation.")
             }
             let uncompressedPublicKey = ucpk
-            guard let _ = uncompressedPublicKey.compressedPublicKey else {
+            guard uncompressedPublicKey.compressedPublicKey != nil else {
                 throw EosioError(.keyManagementError, reason: "Cannot get compressed public key.")
             }
             throw EosioError(.keyManagementError, reason: "Cannot create key")

--- a/EosioSwiftVault/KeychainECKey.swift
+++ b/EosioSwiftVault/KeychainECKey.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import EosioSwift
 
 public extension Keychain {
 
@@ -28,6 +29,29 @@ public extension Keychain {
         private (set) public var uncompressedPublicKey: Data
         /// The compressed public key in ANSI X9.63 format (33 bytes, starts with 02 or 03).
         private (set) public var compressedPublicKey: Data
+        
+
+        static func new(attributes: [String: Any]) throws -> ECKey {
+            if let key = ECKey(attributes: attributes) {
+                return key
+            }
+            guard let privkey = attributes[kSecValueRef as String] else {
+                throw EosioError(.keyManagementError, reason: "Cannot get private key reference.")
+            }
+            let privateSecKey = privkey as! SecKey // swiftlint:disable:this force_cast
+            guard let pubKey = SecKeyCopyPublicKey(privateSecKey) else {
+                throw EosioError(.keyManagementError, reason: "Cannot get public key from private key.")
+            }
+            let publicSecKey = pubKey
+            guard let ucpk = publicSecKey.externalRepresentation else {
+                throw EosioError(.keyManagementError, reason: "Cannot get public key external representation.")
+            }
+            let uncompressedPublicKey = ucpk
+            guard let _ = uncompressedPublicKey.compressedPublicKey else {
+                throw EosioError(.keyManagementError, reason: "Cannot get compressed public key.")
+            }
+            throw EosioError(.keyManagementError, reason: "Cannot create key")
+        }
 
         /// Init an ECKey.
         ///

--- a/EosioSwiftVaultTests/EosioSwiftVaultTests.swift
+++ b/EosioSwiftVaultTests/EosioSwiftVaultTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import EosioSwiftEcc
 @testable import EosioSwiftVault
 
 class EosioSwiftVaultTests: XCTestCase {
@@ -17,18 +18,6 @@ class EosioSwiftVaultTests: XCTestCase {
 
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
     }
 
     func testCompressUncompressR1KeysRoundTrip() {
@@ -43,10 +32,40 @@ class EosioSwiftVaultTests: XCTestCase {
                 return XCTFail("Not a valid key")
             }
 
-            guard let uncompressedPubKey2 = try? keychain.uncompressedR1PublicKey(data: compressedPubKey) else {
+            guard let uncompressedPubKey2 = try? keychain.uncompressedPublicKey(data: compressedPubKey) else {
                 return XCTFail("uncompression error")
             }
             XCTAssertEqual(uncompressedPubKey, uncompressedPubKey2)
          }
     }
+
+    func generatePrivateKeyBytes() -> Data? {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else { return nil }
+        return Data(bytes)
+    }
+
+    func testCompressUncompressK1KeysRoundTrip() {
+        let keychain = Keychain(accessGroup: "")
+        do {
+            for _ in 0...100 {
+               guard let privKey = generatePrivateKeyBytes() else {
+                   return XCTFail("Not a valid pk")
+               }
+               let uncompressedPubKey = try EccRecoverKey.recoverPublicKey(privateKey: privKey, curve: .k1)
+               guard let compressedPubKey = uncompressedPubKey.compressedPublicKey else {
+                   return XCTFail("Not a valid key")
+               }
+               guard let uncompressedPubKey2 = try? keychain.uncompressedPublicKey(data: compressedPubKey, curve: "K1") else {
+                   return XCTFail("uncompression error")
+               }
+               XCTAssertEqual(uncompressedPubKey, uncompressedPubKey2)
+            }
+        } catch {
+            return XCTFail(error.eosioError.reason)
+        }
+
+    }
+
 }

--- a/EosioSwiftVaultTests/EosioSwiftVaultTests.swift
+++ b/EosioSwiftVaultTests/EosioSwiftVaultTests.swift
@@ -31,4 +31,22 @@ class EosioSwiftVaultTests: XCTestCase {
         }
     }
 
+    func testCompressUncompressR1KeysRoundTrip() {
+        let keychain = Keychain(accessGroup: "")
+         for _ in 0...100 {
+            let key = keychain.createEllipticCurvePrivateKey(isPermanent: false)
+            guard let uncompressedPubKey = key?.publicKey?.externalRepresentation else {
+                return XCTFail("Not a valid key")
+            }
+
+            guard let compressedPubKey = uncompressedPubKey.compressedPublicKey else {
+                return XCTFail("Not a valid key")
+            }
+
+            guard let uncompressedPubKey2 = try? keychain.uncompressedR1PublicKey(data: compressedPubKey) else {
+                return XCTFail("uncompression error")
+            }
+            XCTAssertEqual(uncompressedPubKey, uncompressedPubKey2)
+         }
+    }
 }


### PR DESCRIPTION
Update Vault to support more efficient lookup of elliptic curve keys and the ability to add biometric restrictions to keys without triggering a biometric prompt.

The previous version did key lookup based on public key in an inelegant way, by retrieving all keys and looping through the array looking for that public key. This worked ok if there were a small number of keys and none had biometric restrictions.

For elliptic curve keys the keychain automatically sets the `application label` attribute to the sha1 hash of the uncompressed public key and this value can be used for lookup. 

However, for eosio public keys we only have the compressed form so code was added to compute an uncompressed public key from the compressed key and the curve. Support for both R1 and K1 curves is included. A private Data extension was added to compute sha1.

Unit tests were added to do 100 random round trip uncompressed key to compressed key and back to uncompressed key tests. During development tests were run on each with a loop of 10,000 and no errors.

The get key by public key functions in the Keychain and Vault classes now compute the uncompressed public key, then the sha1 hash and use that value for lookup.

When importing keys or creating new keys the key is no longer read back from the keychain, but the ECKey or VaultKey object is created from the existing data so no biometric check is triggered if the key had biometric restrictions.

It is now possible to add biometric restrictions when importing or creating new keys.

Notes were added to the comments on functions that might trigger a biometric prompt.

Another change was made to the `getAllEllipticCurveKeys` function. The query gets all the attributes and then creates an ECKey for each set of key attributes in the array. It was discovered that if there are large number of results returned by the query, the key reference is sometimes nil, resulting in an error when trying to create the ECKey. In these cases querying for the individual key again using the `application label` attribute returns a valid key reference. 

deleteKey in the Vault class uses the `getVaultKey` func and then deletes using the key reference.