### PR TITLE
Create index file for docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+## Code Documentation
+
+The _EOSIO SDK for Swift: Vault_ repo consists of two modules. You can access the generated code documentation for each as follows:
+
+* [Core Vault Library](https://eosio.github.io/eosio-swift-vault/EosioSwiftVault/) (`EosioSwiftVault`)
+* [Vault Signature Provider](https://eosio.github.io/eosio-swift-vault/EosioSwiftVaultSignatureProvider/) (`EosioSwiftVaultSignatureProvider`)


### PR DESCRIPTION
Now that we have subdirectories in the `/docs` directory, we need an index for our docs link.